### PR TITLE
Feat/3

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -48,6 +48,7 @@
     "react/react-in-jsx-scope": "off",
     // "react/require-default-props": "off",
     // "import/prefer-default-export": "off",
+    "consistent-return": "off",
     "import/order": [
       "error",
       {

--- a/app/(main)/pokedex/[pokemonId]/page.tsx
+++ b/app/(main)/pokedex/[pokemonId]/page.tsx
@@ -1,0 +1,30 @@
+import queries from "@/app/service/pokemon/queries";
+import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
+
+import PokedexDetail from "./pokedex-detail";
+
+type Props = {
+  params: {
+    pokemonId: string;
+  };
+};
+
+async function prefetchPokemonDetail(pokemonId: string) {
+  const queryClient = new QueryClient();
+
+  await queryClient.prefetchQuery(queries.detail(pokemonId));
+
+  return queryClient;
+}
+
+export default async function PokedexDetailPage({ params }: Props) {
+  const { pokemonId } = params;
+
+  const queryClient = await prefetchPokemonDetail(pokemonId);
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <PokedexDetail pokemonId={pokemonId} />
+    </HydrationBoundary>
+  );
+}

--- a/app/(main)/pokedex/[pokemonId]/pokedex-detail.tsx
+++ b/app/(main)/pokedex/[pokemonId]/pokedex-detail.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import Image from "next/image";
+
+import { usePokemonDetail } from "@/app/service/pokemon/use-pokemon-service";
+
+type Props = {
+  pokemonId: string;
+};
+
+export default function PokedexDetail({ pokemonId }: Props) {
+  const { data: pokemonDetail } = usePokemonDetail(pokemonId);
+
+  return (
+    <main>
+      <Image
+        src={`${pokemonDetail?.sprites.front_default}`}
+        alt={`Image of ${pokemonDetail?.name}`}
+        width={150}
+        height={150}
+      />
+      <h1>{pokemonDetail?.name}</h1>
+      <p>{pokemonDetail?.height}</p>
+      <p>{pokemonDetail?.weight}</p>
+    </main>
+  );
+}

--- a/app/(main)/pokedex/page.tsx
+++ b/app/(main)/pokedex/page.tsx
@@ -1,0 +1,63 @@
+import queries from "@/app/service/pokemon/queries";
+import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
+
+import Pokedex from "./pokedex";
+
+async function prefetchFirstPage() {
+  const queryClient = new QueryClient();
+
+  await queryClient.prefetchInfiniteQuery({ ...queries.all(), pages: 2 });
+
+  const queryData = queryClient.getQueryData(queries.all().queryKey);
+  // Option 1 (Sequentially Prefetching Each Result)
+  // This method will prefetch each result one by one,
+  // waiting for each prefetchQuery to complete before moving to the next
+
+  // for(const {results} of pages) {
+  //   await Promise.all(
+  //     results.map((pokemonReference) =>
+  //       queryClient.prefetchQuery({
+  //         queryKey: queryOptions.detail(pokemonReference.name).queryKey,
+  //         queryFn: () => queryOptions.detail(pokemonReference.name).queryFn(),
+  //       })
+  //     )
+  //   )
+  // };
+
+  // Option 2 (Prefetching All Results in Parallel per Page)
+  // This method will prefetch all results for a single page in parallel, then move to the next page.
+
+  // for (const { results } of pages) {
+  //   for (const result of results) {
+  //     await queryClient.prefetchQuery({
+  //       queryKey: queryOptions.detail(result.name).queryKey,
+  //       queryFn: () => queryOptions.detail(result.name).queryFn(),
+  //     });
+  //   }
+  // }
+
+  // Option 3 (All Pages and Results in Parallel)
+  // This method will prefetch all results across all pages in parallel, which is the fastest approach but might overwhelm your network or API if there are many results.
+
+  if (queryData) {
+    const { pages } = queryData;
+    await Promise.all(
+      pages.flatMap(({ results }) =>
+        results.map((pokemonReference) =>
+          queryClient.prefetchQuery(queries.detail(pokemonReference.name)),
+        ),
+      ),
+    );
+  }
+
+  return queryClient;
+}
+
+export default async function Page() {
+  const queryClient = await prefetchFirstPage();
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <Pokedex />
+    </HydrationBoundary>
+  );
+}

--- a/app/(main)/pokedex/page.tsx
+++ b/app/(main)/pokedex/page.tsx
@@ -9,35 +9,6 @@ async function prefetchFirstPage() {
   await queryClient.prefetchInfiniteQuery({ ...queries.all(), pages: 2 });
 
   const queryData = queryClient.getQueryData(queries.all().queryKey);
-  // Option 1 (Sequentially Prefetching Each Result)
-  // This method will prefetch each result one by one,
-  // waiting for each prefetchQuery to complete before moving to the next
-
-  // for(const {results} of pages) {
-  //   await Promise.all(
-  //     results.map((pokemonReference) =>
-  //       queryClient.prefetchQuery({
-  //         queryKey: queryOptions.detail(pokemonReference.name).queryKey,
-  //         queryFn: () => queryOptions.detail(pokemonReference.name).queryFn(),
-  //       })
-  //     )
-  //   )
-  // };
-
-  // Option 2 (Prefetching All Results in Parallel per Page)
-  // This method will prefetch all results for a single page in parallel, then move to the next page.
-
-  // for (const { results } of pages) {
-  //   for (const result of results) {
-  //     await queryClient.prefetchQuery({
-  //       queryKey: queryOptions.detail(result.name).queryKey,
-  //       queryFn: () => queryOptions.detail(result.name).queryFn(),
-  //     });
-  //   }
-  // }
-
-  // Option 3 (All Pages and Results in Parallel)
-  // This method will prefetch all results across all pages in parallel, which is the fastest approach but might overwhelm your network or API if there are many results.
 
   if (queryData) {
     const { pages } = queryData;

--- a/app/(main)/pokedex/pokedex.tsx
+++ b/app/(main)/pokedex/pokedex.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useCallback } from "react";
+
+import queries from "@/app/service/pokemon/queries";
+import { usePokemon } from "@/app/service/pokemon/use-pokemon-service";
+import { Pokemon } from "@/app/types/pokemon/pokemon";
+import PokedexCard from "@/app/ui/pokedex/pokedex-card";
+import { useQueries, useQueryClient, UseQueryResult } from "@tanstack/react-query";
+
+// 아래 TODO 해결한 방법
+// usePokemon으로 받아온 data (pokemonPages)는 누적된 데이터이기 때문에 마지막 인덱스만을 대상으로 queries.detail() 쿼리를 호출한다
+// 하지만, 후처리가 없으면 useQueries가 반환하는 데이터는 새로운 데이터만 반환하기 때문에 이전 데이터를 포함해서 반환하도록
+// combine 콜백에서 queryClient.getQueriesData()를 사용해 cache된 이전 데이터를 가져온다.
+// combine 콜백은 호출마다 재생성되므로 useCallback으로 감싸 최적화를 적용했다
+
+export default function Pokedex() {
+  const queryClient = useQueryClient();
+  const { pokemonPages, handleNextPage, isFetchingNextPage } = usePokemon();
+
+  const { data: pokemons, pending } = useQueries({
+    queries: pokemonPages
+      ? pokemonPages[pokemonPages.length - 1].results.map(({ name }) => ({
+          ...queries.detail(name),
+          staleTime: Infinity,
+        }))
+      : [],
+    combine: useCallback(
+      (results: UseQueryResult<Pokemon, Error>[]) => {
+        return {
+          data: queryClient.getQueriesData<Pokemon>({
+            queryKey: queries.all().queryKey,
+            predicate: (query) => query.queryKey.length !== 1,
+          }),
+          pending: results.some((result) => result.isPending),
+        };
+      },
+      [queryClient],
+    ),
+  });
+
+  // TODO: 지금 문제가 되는 부분은 nextPage를 불러올 때마다 pokemonEntries는 이전 데이터를 포함해서 데이터를 업데이트하는데
+  // 이 데이터를 모두 useQueries로 불러오기 때문에 page를 불러올수록 fetch 시간이 길어진다.
+  // 새로 추가되는 부분만 불러오던지 pagination으로 전환하던지 해야할 듯
+  // const { pokemonEntries, handleNextPage, isFetchingNextPage, isLoading } = usePokemon();
+
+  // const { data: pokemons, pending } = useQueries({
+  //   queries: pokemonEntries
+  //     ? pokemonEntries.map((pokemonReference) => ({
+  //         ...queries.detail(pokemonReference.name),
+  //         staleTime: Infinity,
+  //       }))
+  //     : [],
+  //   combine: useCallback((results) => {
+  //     return {
+  //       data: results.map((result) => result.data),
+  //       pending: results.some((result) => result.isPending),
+  //     };
+  //   }, []),
+  // });
+  // const intersectionRef = useRef(null);
+
+  // useIntersectionObserver({
+  //   target: intersectionRef,
+  //   handleIntersect: handleNextPage,
+  // });
+
+  return (
+    <main className="flex flex-col items-center gap-4">
+      <div className="flex flex-wrap gap-1">
+        {pokemons.map(
+          ([, pokemon]) => pokemon && <PokedexCard key={pokemon.id} pokemon={pokemon} />,
+        )}
+      </div>
+      <button
+        className="rounded-md bg-slate-400 p-2 text-white"
+        type="button"
+        onClick={handleNextPage}
+        disabled={isFetchingNextPage || pending}
+      >
+        <p>Load More</p>
+      </button>
+    </main>
+  );
+}

--- a/app/(main)/pokedex/pokedex.tsx
+++ b/app/(main)/pokedex/pokedex.tsx
@@ -1,85 +1,47 @@
 "use client";
 
-import { useCallback } from "react";
-
 import queries from "@/app/service/pokemon/queries";
 import { usePokemon } from "@/app/service/pokemon/use-pokemon-service";
-import { Pokemon } from "@/app/types/pokemon/pokemon";
 import PokedexCard from "@/app/ui/pokedex/pokedex-card";
-import { useQueries, useQueryClient, UseQueryResult } from "@tanstack/react-query";
-
-// 아래 TODO 해결한 방법
-// usePokemon으로 받아온 data (pokemonPages)는 누적된 데이터이기 때문에 마지막 인덱스만을 대상으로 queries.detail() 쿼리를 호출한다
-// 하지만, 후처리가 없으면 useQueries가 반환하는 데이터는 새로운 데이터만 반환하기 때문에 이전 데이터를 포함해서 반환하도록
-// combine 콜백에서 queryClient.getQueriesData()를 사용해 cache된 이전 데이터를 가져온다.
-// combine 콜백은 호출마다 재생성되므로 useCallback으로 감싸 최적화를 적용했다
+import { useQueries } from "@tanstack/react-query";
 
 export default function Pokedex() {
-  const queryClient = useQueryClient();
-  const { pokemonPages, handleNextPage, isFetchingNextPage } = usePokemon();
+  const { pokemonEntries, handleNextPage, isFetchingNextPage, hasNextPage } = usePokemon();
 
-  const { data: pokemons, pending } = useQueries({
-    queries: pokemonPages
-      ? pokemonPages[pokemonPages.length - 1].results.map(({ name }) => ({
-          ...queries.detail(name),
+  const queryResults = useQueries({
+    queries: pokemonEntries
+      ? pokemonEntries.map((reference) => ({
+          ...queries.detail(reference.name),
           staleTime: Infinity,
         }))
       : [],
-    combine: useCallback(
-      (results: UseQueryResult<Pokemon, Error>[]) => {
-        return {
-          data: queryClient.getQueriesData<Pokemon>({
-            queryKey: queries.all().queryKey,
-            predicate: (query) => query.queryKey.length !== 1,
-          }),
-          pending: results.some((result) => result.isPending),
-        };
-      },
-      [queryClient],
-    ),
   });
-
-  // TODO: 지금 문제가 되는 부분은 nextPage를 불러올 때마다 pokemonEntries는 이전 데이터를 포함해서 데이터를 업데이트하는데
-  // 이 데이터를 모두 useQueries로 불러오기 때문에 page를 불러올수록 fetch 시간이 길어진다.
-  // 새로 추가되는 부분만 불러오던지 pagination으로 전환하던지 해야할 듯
-  // const { pokemonEntries, handleNextPage, isFetchingNextPage, isLoading } = usePokemon();
-
-  // const { data: pokemons, pending } = useQueries({
-  //   queries: pokemonEntries
-  //     ? pokemonEntries.map((pokemonReference) => ({
-  //         ...queries.detail(pokemonReference.name),
-  //         staleTime: Infinity,
-  //       }))
-  //     : [],
-  //   combine: useCallback((results) => {
-  //     return {
-  //       data: results.map((result) => result.data),
-  //       pending: results.some((result) => result.isPending),
-  //     };
-  //   }, []),
-  // });
-  // const intersectionRef = useRef(null);
-
-  // useIntersectionObserver({
-  //   target: intersectionRef,
-  //   handleIntersect: handleNextPage,
-  // });
 
   return (
     <main className="flex flex-col items-center gap-4">
       <div className="flex flex-wrap gap-1">
-        {pokemons.map(
-          ([, pokemon]) => pokemon && <PokedexCard key={pokemon.id} pokemon={pokemon} />,
-        )}
+        {queryResults.map(({ isLoading, data }, index) => {
+          if (isLoading || !data)
+            return (
+              <div
+                // eslint-disable-next-line react/no-array-index-key
+                key={`skeleton-${index}`}
+                className="h-[130px] w-[110px] rounded-md bg-slate-100"
+              />
+            );
+          return <PokedexCard key={data.id} pokemon={data} />;
+        })}
       </div>
-      <button
-        className="rounded-md bg-slate-400 p-2 text-white"
-        type="button"
-        onClick={handleNextPage}
-        disabled={isFetchingNextPage || pending}
-      >
-        <p>Load More</p>
-      </button>
+      {hasNextPage && (
+        <button
+          className="rounded-md bg-slate-400 p-2 text-white"
+          type="button"
+          onClick={handleNextPage}
+          disabled={isFetchingNextPage}
+        >
+          <p>Load More</p>
+        </button>
+      )}
     </main>
   );
 }

--- a/app/hooks/useIntersectionObserver.ts
+++ b/app/hooks/useIntersectionObserver.ts
@@ -1,0 +1,43 @@
+import { RefObject, useEffect, useRef } from "react";
+
+type Parameters = {
+  target: RefObject<Element>;
+  handleIntersect: (element: Element) => void;
+  options?: IntersectionObserverInit;
+};
+
+const DEFAULT_OPTIONS = {
+  root: null,
+  rootMargin: "0px",
+  threshold: 0.1,
+};
+
+const useIntersectionObserver = ({
+  target,
+  handleIntersect,
+  options = DEFAULT_OPTIONS,
+}: Parameters): RefObject<IntersectionObserver | null> => {
+  const observerRef = useRef<IntersectionObserver | null>(null);
+
+  useEffect(() => {
+    if (!target.current) return;
+
+    observerRef.current = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          handleIntersect(entry.target);
+        }
+      });
+    }, options);
+
+    observerRef.current.observe(target.current);
+
+    return () => {
+      observerRef.current?.disconnect();
+    };
+  }, [target, options]);
+
+  return observerRef;
+};
+
+export default useIntersectionObserver;

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -9,3 +9,7 @@ export function parseOffset(url: string) {
   const offset = new URL(url).searchParams.get("offset");
   return offset ? parseInt(offset, 10) : 0;
 }
+
+export function formatName(name: string) {
+  return name.charAt(0).toUpperCase() + name.slice(1);
+}

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -1,7 +1,11 @@
 import clsx, { ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 
-// eslint-disable-next-line import/prefer-default-export
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
+}
+
+export function parseOffset(url: string) {
+  const offset = new URL(url).searchParams.get("offset");
+  return offset ? parseInt(offset, 10) : 0;
 }

--- a/app/service/pokemon/pokemon-service.ts
+++ b/app/service/pokemon/pokemon-service.ts
@@ -1,9 +1,21 @@
 import Service from "@/app/service/service";
+import { NamedAPIResource } from "@/app/types/pokemon/common";
 import { Pokemon } from "@/app/types/pokemon/pokemon";
 
+type GetPokemonRequest = {
+  offset?: number;
+  limit?: number;
+};
+
+type GetPokemonResponse = {
+  count: number;
+  next: string;
+  previous?: string;
+  results: NamedAPIResource[];
+};
 class PokemonService extends Service {
-  getPokemon() {
-    return this.http.get<Pokemon[]>("/pokemon");
+  getPokemon({ offset = 0, limit = 20 }: GetPokemonRequest) {
+    return this.http.get<GetPokemonResponse>(`/pokemon?offset=${offset}&limit=${limit}`);
   }
 
   getPokemonDetail(pokemonId: string) {

--- a/app/service/pokemon/queries.ts
+++ b/app/service/pokemon/queries.ts
@@ -1,19 +1,26 @@
+import { parseOffset } from "@/app/lib/utils";
+import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
+
 import PokemonService from "./pokemon-service";
 
 const queryKeys = {
-  all: ["pokemon"] as const,
-  detail: (pokemonId: string) => [...queryKeys.all, pokemonId] as const,
+  all: () => ["pokemon"],
+  detail: (pokemonId: string) => [...queryKeys.all(), pokemonId] as const,
 };
 
-const queryOptions = {
-  all: () => ({
-    queryKey: queryKeys.all,
-    queryFn: () => PokemonService.getPokemon(),
-  }),
-  detail: (pokemonId: string) => ({
-    queryKey: queryKeys.detail(pokemonId),
-    queryFn: () => PokemonService.getPokemonDetail(pokemonId),
-  }),
+const queries = {
+  all: () =>
+    infiniteQueryOptions({
+      queryKey: queryKeys.all(),
+      queryFn: ({ pageParam }) => PokemonService.getPokemon({ offset: pageParam }),
+      getNextPageParam: (lastPage) => parseOffset(lastPage.next),
+      initialPageParam: 0,
+    }),
+  detail: (pokemonId: string) =>
+    queryOptions({
+      queryKey: queryKeys.detail(pokemonId),
+      queryFn: () => PokemonService.getPokemonDetail(pokemonId),
+    }),
 };
 
-export default queryOptions;
+export default queries;

--- a/app/service/pokemon/use-pokemon-service.ts
+++ b/app/service/pokemon/use-pokemon-service.ts
@@ -3,14 +3,9 @@ import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import queryOptions from "./queries";
 
 export function usePokemon() {
-  // const { data, hasNextPage, isFetchingNextPage, fetchNextPage, ...rest } = useInfiniteQuery({
-  //   ...queryOptions.all(),
-  //   select: (returnedData) => returnedData.pages.flatMap((page) => page.results),
-  //   staleTime: Infinity,
-  // });
-
   const { data, hasNextPage, isFetchingNextPage, fetchNextPage, ...rest } = useInfiniteQuery({
     ...queryOptions.all(),
+    select: (returnedData) => returnedData.pages.flatMap((page) => page.results),
     staleTime: Infinity,
   });
 
@@ -21,7 +16,7 @@ export function usePokemon() {
   };
 
   return {
-    pokemonPages: data?.pages,
+    pokemonEntries: data,
     handleNextPage,
     hasNextPage,
     isFetchingNextPage,

--- a/app/service/pokemon/use-pokemon-service.ts
+++ b/app/service/pokemon/use-pokemon-service.ts
@@ -1,9 +1,32 @@
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 
 import queryOptions from "./queries";
 
 export function usePokemon() {
-  return useQuery(queryOptions.all());
+  // const { data, hasNextPage, isFetchingNextPage, fetchNextPage, ...rest } = useInfiniteQuery({
+  //   ...queryOptions.all(),
+  //   select: (returnedData) => returnedData.pages.flatMap((page) => page.results),
+  //   staleTime: Infinity,
+  // });
+
+  const { data, hasNextPage, isFetchingNextPage, fetchNextPage, ...rest } = useInfiniteQuery({
+    ...queryOptions.all(),
+    staleTime: Infinity,
+  });
+
+  const handleNextPage = () => {
+    if (hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  };
+
+  return {
+    pokemonPages: data?.pages,
+    handleNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    ...rest,
+  };
 }
 
 export function usePokemonDetail(pokemonId: string) {

--- a/app/ui/pokedex/pokedex-card.tsx
+++ b/app/ui/pokedex/pokedex-card.tsx
@@ -1,0 +1,38 @@
+import Image from "next/image";
+import Link from "next/link";
+import React, { memo } from "react";
+
+import { formatName } from "@/app/lib/utils";
+import { Pokemon } from "@/app/types/pokemon/pokemon";
+
+type Props = {
+  pokemon: Pokemon;
+};
+
+// API 구조상 새 페이지마다 rerender를 방지할 수 없는 상황이라 판단되어
+// PokedexCard의 렌더링을 최적화하기 위해 memo를 사용했다
+const PokedexCard = memo(function PokedexCard({ pokemon }: Props) {
+  // const renderTimes = useRef(0);
+  // console.log(`render: ${renderTimes.current++}`);
+  return (
+    <Link
+      href={`/pokedex/${pokemon.name}`}
+      key={pokemon.id}
+      className="group relative flex h-auto w-fit flex-col items-center rounded-md p-1 duration-100 hover:bg-slate-100"
+    >
+      <div className="absolute left-0 top-0 h-3 w-3 border-l-4 border-t-4 border-yellow-500 opacity-0 transition-opacity duration-100 group-hover:opacity-100" />
+      <div className="absolute right-0 top-0 h-3 w-3 border-r-4 border-t-4 border-yellow-500 opacity-0 transition-opacity duration-100 group-hover:opacity-100" />
+      <div className="absolute bottom-0 left-0 h-3 w-3 border-b-4 border-l-4 border-yellow-500 opacity-0 transition-opacity duration-100 group-hover:opacity-100" />
+      <div className="absolute bottom-0 right-0 h-3 w-3 border-b-4 border-r-4 border-yellow-500 opacity-0 transition-opacity duration-100 group-hover:opacity-100" />
+      <Image
+        src={pokemon.sprites.front_default}
+        alt={`Image of ${pokemon.name}`}
+        width={100}
+        height={100}
+      />
+      <p className="text-xs">{formatName(pokemon.name)}</p>
+    </Link>
+  );
+});
+
+export default PokedexCard;

--- a/app/ui/pokedex/pokedex-card.tsx
+++ b/app/ui/pokedex/pokedex-card.tsx
@@ -9,16 +9,12 @@ type Props = {
   pokemon: Pokemon;
 };
 
-// API 구조상 새 페이지마다 rerender를 방지할 수 없는 상황이라 판단되어
-// PokedexCard의 렌더링을 최적화하기 위해 memo를 사용했다
 const PokedexCard = memo(function PokedexCard({ pokemon }: Props) {
-  // const renderTimes = useRef(0);
-  // console.log(`render: ${renderTimes.current++}`);
   return (
     <Link
       href={`/pokedex/${pokemon.name}`}
       key={pokemon.id}
-      className="group relative flex h-auto w-fit flex-col items-center rounded-md p-1 duration-100 hover:bg-slate-100"
+      className="group relative flex h-[130px] w-[110px] flex-col items-center p-1 duration-100 hover:bg-slate-100"
     >
       <div className="absolute left-0 top-0 h-3 w-3 border-l-4 border-t-4 border-yellow-500 opacity-0 transition-opacity duration-100 group-hover:opacity-100" />
       <div className="absolute right-0 top-0 h-3 w-3 border-r-4 border-t-4 border-yellow-500 opacity-0 transition-opacity duration-100 group-hover:opacity-100" />

--- a/app/ui/providers.tsx
+++ b/app/ui/providers.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { isServer, QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
 type Props = {
   children: React.ReactNode;
@@ -29,5 +30,10 @@ function getQueryClient() {
 export default function Providers({ children }: Props) {
   const queryCLient = getQueryClient();
 
-  return <QueryClientProvider client={queryCLient}>{children}</QueryClientProvider>;
+  return (
+    <QueryClientProvider client={queryCLient}>
+      {children}
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
+  );
 }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,13 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "raw.githubusercontent.com",
+      },
+    ],
+  },
+};
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@heroicons/react": "^2.1.5",
     "@tanstack/react-query": "^5.52.1",
+    "@tanstack/react-query-devtools": "^5.52.2",
     "clsx": "^2.1.1",
     "next": "14.2.5",
     "react": "^18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.52.1
         version: 5.52.1(react@18.3.1)
+      '@tanstack/react-query-devtools':
+        specifier: ^5.52.2
+        version: 5.52.2(@tanstack/react-query@5.52.1(react@18.3.1))(react@18.3.1)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -342,6 +345,15 @@ packages:
 
   '@tanstack/query-core@5.52.0':
     resolution: {integrity: sha512-U1DOEgltjUwalN6uWYTewSnA14b+tE7lSylOiASKCAO61ENJeCq9VVD/TXHA6O5u9+6v5+UgGYBSccTKDoyMqw==}
+
+  '@tanstack/query-devtools@5.51.16':
+    resolution: {integrity: sha512-ajwuq4WnkNCMj/Hy3KR8d3RtZ6PSKc1dD2vs2T408MdjgKzQ3klVoL6zDgVO7X+5jlb5zfgcO3thh4ojPhfIaw==}
+
+  '@tanstack/react-query-devtools@5.52.2':
+    resolution: {integrity: sha512-QI3jsi8sVA805F9NRdL/sVGgCUzVD8lr6/ts9v3ZtECG864YDW3GJwEWH030U+4aPvxMtxaJz7ctbtE7Wkxh1g==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.52.2
+      react: ^18 || ^19
 
   '@tanstack/react-query@5.52.1':
     resolution: {integrity: sha512-soyn4dNIUZ8US8NaPVXv06gkZFHaZnPfKWPDjRJjFRW3Y7WZ0jx72eT6zhw3VQlkMPysmXye8l35ewPHspKgbQ==}
@@ -2493,6 +2505,14 @@ snapshots:
       tslib: 2.6.3
 
   '@tanstack/query-core@5.52.0': {}
+
+  '@tanstack/query-devtools@5.51.16': {}
+
+  '@tanstack/react-query-devtools@5.52.2(@tanstack/react-query@5.52.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-devtools': 5.51.16
+      '@tanstack/react-query': 5.52.1(react@18.3.1)
+      react: 18.3.1
 
   '@tanstack/react-query@5.52.1(react@18.3.1)':
     dependencies:


### PR DESCRIPTION
## #️⃣연관된 이슈

> [#3] Feat: Implement Home Page

## 📝작업 내용

- [x] `/app/pokedex/` 경로 생성
- [x] page.tsx 구현(server)
- [x] Pokedex 컴포넌트 (client) 구현
- [x] PokedexCard 컴포넌트 구현 (client)
- [x] page.tsx에서 getPokemon API prefetch 로직 추가
- [x] API 반환 image 경로가 허용되도록 next.config.mjs 수정
- [x] `/pokemon` endpoint 서비스 query factory에 `queryOptions` API 적용
- [x] GET '/pokemon' API 핸들러 bugfix


### 스크린샷 (선택)


## 💬회고
- prefetch 시 발생하는 network waterfall을 최적화하기 위해 고민했습니다
```tsx
  // Option 1 : page를 순차적으로 접근하여 page의 각 query도 순차적으로 prefetch
  // result를 순차적으로 순회하며 각 result에 대한 prefetch가 완료되길 기다린 뒤, 다음 result를 접근합니다

  for(const {results} of pages) {
    await Promise.all(
      results.map((pokemonReference) =>
        queryClient.prefetchQuery({
          queryKey: queryOptions.detail(pokemonReference.name).queryKey,
          queryFn: () => queryOptions.detail(pokemonReference.name).queryFn(),
        })
      )
    )
  };

  // Option 2 : page를 순차적으로 접근하여 page의 query들을 병렬적으로 prefetch
  // page의 result들을 병렬적으로 prefetch하고 모든 query가 완료되면 다음 page에 접근합니다

  for (const { results } of pages) {
    for (const result of results) {
      await queryClient.prefetchQuery({
        queryKey: queryOptions.detail(result.name).queryKey,
        queryFn: () => queryOptions.detail(result.name).queryFn(),
      });
    }
  }

  // Option 3 (All Pages and Results in Parallel)
  // 모든 page의 query들을 병렬적으로 prefetch합니다. query가 많아질수록 네트워크 부하가 커지는 것을 주의해야 합니다.
  if (queryData) {
    const { pages } = queryData;
    await Promise.all(
      pages.flatMap(({ results }) =>
        results.map((pokemonReference) =>
          queryClient.prefetchQuery(queries.detail(pokemonReference.name)),
        ),
      ),
    );
  }
```
해당 상황에서는 infiniteQuery의 첫 1개 또는 2개 (추후 결정) page의 데이터 (page 별 20개 query)를 prefetch하는 것이기 때문에 tradeoff를 고려했을 때 Option3가 가장 적합하다 판단했습니다.

- 무한 스크롤 UX에 대해 고민했습니다
   - intersectionObserver를 활용한 전통적인 무한 스크롤 UX
   - 아이템 리스트 하단의 Button을 활용한 무한 스크롤 UX
   - pagination UX

- 데이터 로딩 시 UX를 고민했습니다
`Pokedex.tsx`의 초기 설계 중 PokedexCard 리스트를 렌더하는 로직은 다음과 같았습니다
```tsx
return (
    <main className="flex flex-col items-center gap-4">
      <div className="flex flex-wrap gap-1">
        {pokemons.map(
          ([, pokemon]) => pokemon && <PokedexCard key={pokemon.id} pokemon={pokemon} />,
        )}
      </div>
   // ...
   </main>
)
```
`pokemon` 값이 유효할 시에만 UI가 렌더링되도록 구현했습니다. pokemon 데이터를 가져오는 API fetch는 병렬적으로 진행됩니다. 데이터 id가 후순위더라도 먼저 로딩된 데이터의 UI가 렌더링되기 때문에 새로 로딩되는 PokemonCard들의 layout이 뒤바뀌면서 깨지는 듯한 side effect가 발생했습니다. 
![feat3_layoutshift](https://github.com/user-attachments/assets/204e27e4-df39-4392-b597-6e7b861ea914)

   - 해결안: 위 side effect는 data 로딩 중과 완료 상태일 때의 UI간의 layout이 달라 발생한 문제입니다. 따라서 아래와 같이
```tsx
return (
    <main className="flex flex-col items-center gap-4">
      <div className="flex flex-wrap gap-1">
        {queryResults.map(({ isLoading, data }, index) => {
          if (isLoading || !data)
            return (
              <Skeleton />
            );
          return <PokedexCard key={data.id} pokemon={data} />;
        })}
      </div>
   </main>
)
```
 데이터 로딩 상태일 때부터 각 PokedexCard의 layout을 skeleton으로 고정하여 layout이 바뀌는 문제를 해결했습니다
![feat3_layoutshift_solve](https://github.com/user-attachments/assets/d2b07719-a328-4736-987c-9e01abc9ad58)

- 페이지 구성요소의 colocation에 대해 고민했습니다
 
- 사용하는 API 스키마와 가장 적합한 react-query 사용법에 대해 고민했습니다
   - `/pokedex` 페이지에서 사용하는 api schema는 다음과 같습니다
      1.  `GET /pokemon` 은 아래 형식의 데이터를 반환합니다
      ```tsx
         {
            count: number;
            next: string;
            previous?: string;
            results: {
                  name: string;
                  url: string; 
            }[]
         }[]
      ``` 
     2. `a` 과정이 완료되면 각 `results.url`마다 `GET /pokemon/{id}`를 요청합니다. 해당 요청의 결과에 `sprite`과 같은 실질적인 포켓몬의 데이터가 있습니다.
  
  - 시도한 접근법은 2가지입니다
1. useInfiniteQuery 데이터의 마지막 page만 useQueries에 사용
 useInfiniteQuery는 모든 page 요청을 하나의 data 항목에 반환합니다. 따라서 page 요청마다 useQueries에 들어가는 query 수가 선형적으로 늘어나 API 요청이 page요청마다 비약적으로 증가할 것이라 우려했습니다. 중복된 쿼리를 방지하기 위해 이전 page들의 데이터는 제외하고 가장 최근에 받아온 page만 파싱하여 useQueries를 통해 호출했습니다. 대신, 이때 useQueries의 반환된 데이터는 이전 page들의 useQueries로 받아온 데이터가 없기 때문에 `combine` 콜백에서 `queryClient.getQueryData`를 활용했습니다.
         - 장점 : 캐싱 정책을 고려하지 않아도 쿼리 중복 문제를 해결합니다
         - 단점 : useQuery의 결과값을 활용하는 것이 아니라 `getQueryData`를 사용하여 캐시에 접근하기 때문에 로직이 직관적이지 않고 best practice와 거리가 멀다고 생각했습니다
```tsx
const { pokemonPages, handleNextPage, isFetchingNextPage } = usePokemon();
const { data: pokemons, pending } = useQueries({
    queries: pokemonPages
      ? pokemonPages[pokemonPages.length - 1].results.map(({ name }) => ({
          ...queries.detail(name),
        }))
      : [],
    combine: useCallback(
      (results: UseQueryResult<Pokemon, Error>[]) => {
        return {
          data: queryClient.getQueriesData<Pokemon>({
            queryKey: queries.all().queryKey,
            predicate: (query) => query.queryKey.length !== 1,
          }),
          pending: results.some((result) => result.isPending),
        };
      },
      [queryClient],
    ),
  });
```

2. 쿼리의 staleTime을 조정하여 한번 요청한 쿼리 캐싱을 보장
staleTime을 Infinity로 설정하여 각 쿼리가 refetch되지 않도록 지정한 뒤, useInfiniteQuery의 데이터를 별다른 후처리 없이 useQueries에 사용했습니다. 중복된 쿼리는 데이터 요청 없이 캐시에서 바로 데이터를 가져와 쿼리들이 선형적으로 증가해도 데이터 요청에 걸리는 시간은 유지할 수 있었습니다.
         - 장점 : 쉽게 이해할 수 있는 로직, 각각의 query의 서버 상태 조작 가능

```tsx
  const { pokemonEntries, handleNextPage, isFetchingNextPage, hasNextPage } = usePokemon();

  const queryResults = useQueries({
    queries: pokemonEntries
      ? pokemonEntries.map((reference) => ({
          ...queries.detail(reference.name),
          staleTime: Infinity,
        }))
      : [],
  });
```
- `tanstack/react-query` `v5`에 추가된 `queryOptions` API를 활용해 query 설정 관리에 대한 best practice를 고민했습니다
   - [TkDodo의 블로그](https://tkdodo.eu/blog/the-query-options-api)를 참고했습니다

## 📍 기타 (선택)

Closes #3